### PR TITLE
Fix ambiguous pointer comparisons by excluding metadata

### DIFF
--- a/src/identity.rs
+++ b/src/identity.rs
@@ -39,7 +39,7 @@ impl<P: Pointer> From<P> for PointerIdentity<P> {
 
 impl<P: Pointer> PartialEq for PointerIdentity<P> {
     fn eq(&self, other: &Self) -> bool {
-        self.0.get() == other.0.get()
+        std::ptr::addr_eq(self.0.get(), other.0.get())
     }
 }
 
@@ -47,13 +47,13 @@ impl<P: Pointer> Eq for PointerIdentity<P> {}
 
 impl<P: Pointer> PartialOrd for PointerIdentity<P> {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.0.get().cmp(&other.0.get()))
+        Some(self.0.get().cast::<()>().cmp(&other.0.get().cast::<()>()))
     }
 }
 
 impl<P: Pointer> Ord for PointerIdentity<P> {
     fn cmp(&self, other: &Self) -> Ordering {
-        self.0.get().cmp(&other.0.get())
+        self.0.get().cast::<()>().cmp(&other.0.get().cast::<()>())
     }
 }
 


### PR DESCRIPTION
This PR addresses the following `cargo clippy` warnings:

```terminal
warning: ambiguous wide pointer comparison, the comparison includes metadata which may not be expected
  --> src/identity.rs:42:9
   |
42 |         self.0.get() == other.0.get()
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(ambiguous_wide_pointer_comparisons)]` on by default
help: use `std::ptr::addr_eq` or untyped pointers to only compare their addresses
   |
42 |         std::ptr::addr_eq(self.0.get(), other.0.get())
   |         ++++++++++++++++++            ~              +
help: use explicit `std::ptr::eq` method to compare metadata and addresses
   |
42 |         std::ptr::eq(self.0.get(), other.0.get())
   |         +++++++++++++            ~              +

warning: ambiguous wide pointer comparison, the comparison includes metadata which may not be expected
  --> src/identity.rs:50:14
   |
50 |         Some(self.0.get().cmp(&other.0.get()))
   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
help: use `std::ptr::addr_eq` or untyped pointers to only compare their addresses
   |
50 |         Some(self.0.get().cast::<()>().cmp(&other.0.get().cast::<()>()))
   |                          +++++++++++++                   +++++++++++++

warning: ambiguous wide pointer comparison, the comparison includes metadata which may not be expected
  --> src/identity.rs:56:9
   |
56 |         self.0.get().cmp(&other.0.get())
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
help: use `std::ptr::addr_eq` or untyped pointers to only compare their addresses
   |
56 |         self.0.get().cast::<()>().cmp(&other.0.get().cast::<()>())
   |                     +++++++++++++                   +++++++++++++
```