### PR TITLE
Add optional support for `triomphe::Arc`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ categories = ["rust-patterns"]
 [dependencies]
 bytes = { version = "1.5.0", optional = true }
 serde = { version = "1.0.192", features = ["derive"], optional = true }
+triomphe = { version = "0.1.14", optional = true }
 
 [dev-dependencies]
 proptest = "1.4.0"
@@ -24,6 +25,7 @@ rand = "0.8.5"
 default = []
 serde = ["dep:serde"]
 bytes = ["dep:bytes"]
+triomphe = ["dep:triomphe"]
 
 [[bench]]
 name = "benches"

--- a/src/pointer.rs
+++ b/src/pointer.rs
@@ -1,6 +1,8 @@
 mod builtin;
 #[cfg(feature = "bytes")]
 mod bytes;
+#[cfg(feature = "triomphe")]
+mod triomphe;
 
 /// Type that stores its value in an allocation and can retrieve a pointer to the value.
 pub trait Pointer {

--- a/src/pointer/triomphe.rs
+++ b/src/pointer/triomphe.rs
@@ -1,0 +1,11 @@
+use triomphe::Arc;
+
+use super::Pointer;
+
+impl<T: ?Sized> Pointer for Arc<T> {
+    type Target = T;
+
+    fn get(&self) -> *const Self::Target {
+        Self::as_ptr(self)
+    }
+}

--- a/tests/identity.rs
+++ b/tests/identity.rs
@@ -79,9 +79,13 @@ fn can_compare_cloned_identity() {
     test_cloned_identity(&[] as &[()]);
     test_cloned_identity(&[] as &[(); 0]);
 
-    // other
+    // bytes
     #[cfg(feature = "bytes")]
     test_cloned_identity(bytes::Bytes::from(vec![0]));
+
+    // triomphe
+    #[cfg(feature = "triomphe")]
+    test_cloned_identity(triomphe::Arc::new(()));
 }
 
 fn test_different<T: Pointer>(left: T, right: T) {
@@ -153,9 +157,13 @@ fn can_compare_methods() {
     test_methods(&[] as &[()]);
     test_methods(&[] as &[(); 0]);
 
-    // other
+    // bytes
     #[cfg(feature = "bytes")]
     test_methods(bytes::Bytes::from(vec![0]));
+
+    // triomphe
+    #[cfg(feature = "triomphe")]
+    test_methods(triomphe::Arc::new(0u64));
 }
 
 #[test]


### PR DESCRIPTION
The `triomphe` crate is a rather popular one:

|                    |            |
| ------------------ | ---------- |
| Dependents         | 52         |
| All-Time Downloads | 23,068,548 |
| Recent Downloads   | 5,851,525  |

The crate provides more types than just `triomphe::Arc<T>`, such as `ThinArc<H, T>` and `UniqueArc<T>`, but neither of those provide a typed pointer to their pointee `T`.